### PR TITLE
Allow the RequestValidationResult to be constructed/hydrated externally

### DIFF
--- a/QueueIT.KnownUserV3.SDK/Models.cs
+++ b/QueueIT.KnownUserV3.SDK/Models.cs
@@ -10,6 +10,23 @@ namespace QueueIT.KnownUserV3.SDK
         {
             ActionType = actionType;
         }
+        
+        public RequestValidationResult(
+            string actionType,
+            string redirectUrl,
+            string queueId,
+            string eventId,
+            string actionType,
+            string redirectType,
+            bool isAjaxResult)
+        {
+            ActionType = actionType;
+            RedirectUrl = redirectUrl;
+            QueueId = queueId;
+            EventId = eventId;
+            RedirectType = redirectType;
+            IsAjaxResult = isAjaxResult;
+        }
 
         public string RedirectUrl { get; internal set; }
         public string QueueId { get; internal set; }


### PR DESCRIPTION
The RequestValidationResult doesn't allow an external library to populate the properties for unit testing. This change allows us to build this object with mocking every property.