### PR TITLE
Allow a caller of the KnownUser.ValidateRequestByIntegrationConfig to…

### DIFF
--- a/QueueIT.KnownUserV3.SDK.Tests/UserInQueueServiceTest.cs
+++ b/QueueIT.KnownUserV3.SDK.Tests/UserInQueueServiceTest.cs
@@ -40,7 +40,7 @@ namespace QueueIT.KnownUserV3.SDK.Tests
             Assert.True(result.QueueId == queueId);
             Assert.True(result.RedirectType == "idle");
 
-            cookieProviderMock.AssertWasNotCalled(stub => stub.Store("", queueId, null, "", "", ""),
+            cookieProviderMock.AssertWasNotCalled(stub => stub.Store("", queueId, null, "", "", "", null),
                    options => options.IgnoreArguments());
             Assert.True(config.EventId == result.EventId);
         }
@@ -77,7 +77,8 @@ namespace QueueIT.KnownUserV3.SDK.Tests
                                 Arg<int?>.Is.Equal(null),
                                 Arg<string>.Is.Equal(config.CookieDomain),
                                 Arg<string>.Is.Equal("disabled"),
-                                Arg<string>.Is.Equal("key")));
+                                Arg<string>.Is.Equal("key"),
+                                Arg<bool?>.Is.Equal(null)));
             cookieProviderMock.AssertWasCalled(stub => stub.GetState("e1", 20, "key"));
             Assert.True(config.EventId == result.EventId);
         }
@@ -109,7 +110,7 @@ namespace QueueIT.KnownUserV3.SDK.Tests
             Assert.True(result.RedirectType == "idle");
             Assert.True(!result.DoRedirect);
             cookieProviderMock.AssertWasNotCalled(stub =>
-                                stub.Store(null, null, 0, null, "", null), options => options.IgnoreArguments());
+                                stub.Store(null, null, 0, null, "", null, null), options => options.IgnoreArguments());
             Assert.True(config.EventId == result.EventId);
             cookieProviderMock.AssertWasCalled(stub => stub.GetState("e1", 10, customerKey));
         }
@@ -165,7 +166,7 @@ namespace QueueIT.KnownUserV3.SDK.Tests
             var redirectUrl = regex.Replace(result.RedirectUrl, "");
             Assert.True(redirectUrl.ToUpper() == expectedErrorUrl.ToUpper());
             Assert.True(config.EventId == result.EventId);
-            cookieProviderMock.AssertWasNotCalled(stub => stub.Store("", "", null, "", "", ""),
+            cookieProviderMock.AssertWasNotCalled(stub => stub.Store("", "", null, "", "", "", null),
                 options => options.IgnoreArguments());
         }
 
@@ -216,7 +217,7 @@ namespace QueueIT.KnownUserV3.SDK.Tests
             var redirectUrl = regex.Replace(result.RedirectUrl, "");
             Assert.True(redirectUrl.ToUpper() == expectedErrorUrl.ToUpper());
             Assert.True(config.EventId == result.EventId);
-            cookieProviderMock.AssertWasNotCalled(stub => stub.Store("", "", null, "", null, ""),
+            cookieProviderMock.AssertWasNotCalled(stub => stub.Store("", "", null, "", null, "", null),
                 options => options.IgnoreArguments());
         }
 
@@ -267,7 +268,7 @@ namespace QueueIT.KnownUserV3.SDK.Tests
             var redirectUrl = regex.Replace(result.RedirectUrl, "");
             Assert.True(redirectUrl.ToUpper() == expectedErrorUrl.ToUpper());
             Assert.True(config.EventId == result.EventId);
-            cookieProviderMock.AssertWasNotCalled(stub => stub.Store("", "", null, "", null, ""),
+            cookieProviderMock.AssertWasNotCalled(stub => stub.Store("", "", null, "", null, "", null),
                 options => options.IgnoreArguments());
         }
 
@@ -311,7 +312,8 @@ namespace QueueIT.KnownUserV3.SDK.Tests
                                      Arg<int?>.Is.Equal(null),
                                      Arg<string>.Is.Equal(config.CookieDomain),
                                      Arg<string>.Is.Equal("queue"),
-                                     Arg<string>.Is.Equal(customerKey)));
+                                     Arg<string>.Is.Equal(customerKey),
+                                     Arg<bool?>.Is.Equal(null)));
             Assert.True(result.QueueId == queueId);
             Assert.True(result.RedirectType == "queue");
             Assert.True(config.EventId == result.EventId);
@@ -355,8 +357,8 @@ namespace QueueIT.KnownUserV3.SDK.Tests
                                      Arg<int?>.Is.Equal(3),
                                      Arg<string>.Is.Equal(config.CookieDomain),
                                      Arg<string>.Is.Equal("DirectLink"),
-                                     Arg<string>.Is.Equal(customerKey)));
-
+                                     Arg<string>.Is.Equal(customerKey),
+                                     Arg<bool?>.Is.Equal(null)));
         }
 
         [Fact]
@@ -392,7 +394,7 @@ namespace QueueIT.KnownUserV3.SDK.Tests
             Assert.True(result.DoRedirect);
             Assert.True(result.RedirectUrl.ToUpper() == expectedUrl.ToUpper());
             cookieProviderMock.AssertWasNotCalled(stub =>
-                                stub.Store(null, null, null, null, null, null), options => options.IgnoreArguments());
+                                stub.Store(null, null, null, null, null, null, null), options => options.IgnoreArguments());
             Assert.True(config.EventId == result.EventId);
         }
 
@@ -428,7 +430,7 @@ namespace QueueIT.KnownUserV3.SDK.Tests
             Assert.True(result.DoRedirect);
             Assert.True(result.RedirectUrl.ToUpper() == expectedUrl.ToUpper());
             cookieProviderMock.AssertWasNotCalled(stub =>
-                                stub.Store(null, null, null, null, null, null), options => options.IgnoreArguments());
+                                stub.Store(null, null, null, null, null, null, null), options => options.IgnoreArguments());
             Assert.True(config.EventId == result.EventId);
         }
 
@@ -465,7 +467,7 @@ namespace QueueIT.KnownUserV3.SDK.Tests
             Assert.True(result.DoRedirect);
             Assert.True(result.RedirectUrl.StartsWith($"https://testDomain.com/error/hash/?c=testCustomer&e=e1&ver=v3-aspnet-{knownUserVersion}&cver=10&l=testlayout&queueittoken=ts_sasa~cv_adsasa~ce_falwwwse~q_944c1f44-60dd-4e37-aabc-f3e4bb1c8895&"));
             cookieProviderMock.AssertWasNotCalled(stub =>
-                                stub.Store(null, null, null, null, null, null), options => options.IgnoreArguments());
+                                stub.Store(null, null, null, null, null, null, null), options => options.IgnoreArguments());
             Assert.True(config.EventId == result.EventId);
 
         }

--- a/QueueIT.KnownUserV3.SDK.Tests/UserInQueueStateCookieRepositoryTest.cs
+++ b/QueueIT.KnownUserV3.SDK.Tests/UserInQueueStateCookieRepositoryTest.cs
@@ -30,7 +30,7 @@ namespace QueueIT.KnownUserV3.SDK.Tests
             fakeResponse.Stub(stub => stub.Cookies).Return(cookies);
 
             var testObject = new UserInQueueStateCookieRepository(fakeContext);
-            testObject.Store(eventId, queueId, null, cookieDomain, "Queue", secretKey);
+            testObject.Store(eventId, queueId, null, cookieDomain, "Queue", secretKey, null);
             var cookieValues = CookieHelper.ToNameValueCollectionFromValue(cookies[cookieKey].Value);
             Assert.True(cookies[cookieKey].Expires.Subtract(DateTime.UtcNow.AddDays(1)) < TimeSpan.FromMinutes(1));
             Assert.True(
@@ -76,7 +76,7 @@ namespace QueueIT.KnownUserV3.SDK.Tests
 
             var testObject = new UserInQueueStateCookieRepository(fakeContext);
 
-            testObject.Store(eventId, queueId, cookieValidity, cookieDomain, "idle", secretKey);
+            testObject.Store(eventId, queueId, cookieValidity, cookieDomain, "idle", secretKey, null);
 
             var cookieValues = CookieHelper.ToNameValueCollectionFromValue(cookies[cookieKey].Value);
             Assert.True(cookieValues[_FixedCookieValidityMinutesKey] == "3");
@@ -120,7 +120,7 @@ namespace QueueIT.KnownUserV3.SDK.Tests
             fakeResponse.Stub(stub => stub.Cookies).Return(cookies);
 
             var testObject = new UserInQueueStateCookieRepository(fakeContext);
-            testObject.Store(eventId, queueId, 3, cookieDomain, "idle", secretKey);
+            testObject.Store(eventId, queueId, 3, cookieDomain, "idle", secretKey, null);
             Assert.True(cookies[cookieKey].Expires.Subtract(DateTime.UtcNow.AddDays(1)) < TimeSpan.FromMinutes(1));
             Assert.True(cookies[cookieKey].Domain == cookieDomain);
 
@@ -158,7 +158,7 @@ namespace QueueIT.KnownUserV3.SDK.Tests
             fakeResponse.Stub(stub => stub.Cookies).Return(cookies);
 
             var testObject = new UserInQueueStateCookieRepository(fakeContext);
-            testObject.Store(eventId, queueId, 3, cookieDomain, "idle", secretKey);
+            testObject.Store(eventId, queueId, 3, cookieDomain, "idle", secretKey, null);
             Assert.True(cookies[cookieKey].Expires.Subtract(DateTime.UtcNow.AddDays(1)) < TimeSpan.FromMinutes(1));
             Assert.True(cookies[cookieKey].Domain == cookieDomain);
 
@@ -198,7 +198,7 @@ namespace QueueIT.KnownUserV3.SDK.Tests
 
             var testObject = new UserInQueueStateCookieRepository(fakeContext);
 
-            testObject.Store(eventId, queueId, null, cookieDomain, "idle", secretKey);
+            testObject.Store(eventId, queueId, null, cookieDomain, "idle", secretKey, null);
             Assert.True(cookies[cookieKey].Expires.Subtract(DateTime.UtcNow.AddDays(1)) < TimeSpan.FromMinutes(1));
             Assert.True(cookies[cookieKey].Domain == cookieDomain);
 
@@ -237,7 +237,7 @@ namespace QueueIT.KnownUserV3.SDK.Tests
 
             var testObject = new UserInQueueStateCookieRepository(fakeContext);
 
-            testObject.Store(eventId, queueId, null, cookieDomain, "queue", secretKey);
+            testObject.Store(eventId, queueId, null, cookieDomain, "queue", secretKey, null);
             Assert.True(cookies[cookieKey].Expires.Subtract(DateTime.UtcNow.AddDays(1)) < TimeSpan.FromMinutes(1));
             Assert.True(cookies[cookieKey].Domain == cookieDomain);
 

--- a/QueueIT.KnownUserV3.SDK/KnownUser.cs
+++ b/QueueIT.KnownUserV3.SDK/KnownUser.cs
@@ -14,7 +14,7 @@ namespace QueueIT.KnownUserV3.SDK
 
         public static RequestValidationResult ValidateRequestByIntegrationConfig(
             string currentUrlWithoutQueueITToken, string queueitToken,
-            CustomerIntegration customerIntegrationInfo, string customerId, string secretKey)
+            CustomerIntegration customerIntegrationInfo, string customerId, string secretKey, bool? cookieHttpOnly = null)
         {
             var debugEntries = new Dictionary<string, string>();
 
@@ -54,7 +54,7 @@ namespace QueueIT.KnownUserV3.SDK
                     case ""://baackward compatibility
                     case ActionType.QueueAction:
                         {
-                            return HandleQueueAction(currentUrlWithoutQueueITToken, queueitToken, customerIntegrationInfo, customerId, secretKey, debugEntries, matchedConfig);
+                            return HandleQueueAction(currentUrlWithoutQueueITToken, queueitToken, customerIntegrationInfo, customerId, secretKey, debugEntries, matchedConfig, cookieHttpOnly);
                         }
                     case ActionType.CancelAction:
                         {
@@ -247,7 +247,7 @@ namespace QueueIT.KnownUserV3.SDK
             string currentUrlWithoutQueueITToken, string queueitToken,
             CustomerIntegration customerIntegrationInfo, string customerId,
             string secretKey, Dictionary<string, string> debugEntries,
-            IntegrationConfigModel matchedConfig)
+            IntegrationConfigModel matchedConfig, bool? cookieHttpOnly)
         {
             var targetUrl = "";
             switch (matchedConfig.RedirectLogic)
@@ -273,6 +273,7 @@ namespace QueueIT.KnownUserV3.SDK
                 LayoutName = matchedConfig.LayoutName,
                 CookieValidityMinute = matchedConfig.CookieValidityMinute.Value,
                 CookieDomain = matchedConfig.CookieDomain,
+                CookieHttpOnly = cookieHttpOnly,
                 Version = customerIntegrationInfo.Version
             };
 

--- a/QueueIT.KnownUserV3.SDK/Models.cs
+++ b/QueueIT.KnownUserV3.SDK/Models.cs
@@ -56,6 +56,7 @@ namespace QueueIT.KnownUserV3.SDK
         public bool ExtendCookieValidity { get; set; }
         public int CookieValidityMinute { get; set; }
         public string CookieDomain { get; set; }
+        public bool? CookieHttpOnly { get; set; }
         public int Version { get; set; }
         public override string ToString()
         {

--- a/QueueIT.KnownUserV3.SDK/UserInQueueService.cs
+++ b/QueueIT.KnownUserV3.SDK/UserInQueueService.cs
@@ -55,7 +55,8 @@ namespace QueueIT.KnownUserV3.SDK
                         null,
                         config.CookieDomain,
                         state.RedirectType,
-                        secretKey);
+                        secretKey,
+                        config.CookieHttpOnly);
                 }
                 return new RequestValidationResult(ActionType.QueueAction)
                 {
@@ -101,7 +102,8 @@ namespace QueueIT.KnownUserV3.SDK
                 queueParams.CookieValidityMinutes,
                 config.CookieDomain,
                 queueParams.RedirectType,
-                secretKey);
+                secretKey,
+                config.CookieHttpOnly);
 
             return new RequestValidationResult(ActionType.QueueAction)
             {

--- a/QueueIT.KnownUserV3.SDK/UserInQueueStateCookieRepository.cs
+++ b/QueueIT.KnownUserV3.SDK/UserInQueueStateCookieRepository.cs
@@ -13,7 +13,8 @@ namespace QueueIT.KnownUserV3.SDK
             int? fixedCookieValidityMinutes,
             string cookieDomain,
             string redirectType,
-            string secretKey);
+            string secretKey,
+						bool? cookieHttpOnly);
 
         StateInfo GetState(
             string eventId,
@@ -59,14 +60,15 @@ namespace QueueIT.KnownUserV3.SDK
             int? fixedCookieValidityMinutes,
             string cookieDomain,
             string redirectType,
-            string secretKey)
+            string secretKey,
+            bool? cookieHttpOnly)
         {
             var cookieKey = GetCookieKey(eventId);
 
             var cookie = CreateCookie(
                 eventId, queueId,
                 Convert.ToString(fixedCookieValidityMinutes),
-                redirectType, cookieDomain, secretKey);
+                redirectType, cookieDomain, secretKey, cookieHttpOnly);
 
             if (_httpContext.Response.Cookies.AllKeys.Any(key => key == cookieKey))
                 _httpContext.Response.Cookies.Remove(cookieKey);
@@ -147,7 +149,7 @@ namespace QueueIT.KnownUserV3.SDK
                 eventId, cookieValues[_QueueIdKey],
                 cookieValues[_FixedCookieValidityMinutesKey],
                 cookieValues[_RedirectTypeKey],
-                cookie.Domain, secretKey);
+                cookie.Domain, secretKey, cookie.HttpOnly);
 
             if (_httpContext.Response.Cookies.AllKeys.Any(key => key == cookieKey))
                 _httpContext.Response.Cookies.Remove(cookieKey);
@@ -161,7 +163,8 @@ namespace QueueIT.KnownUserV3.SDK
             string fixedCookieValidityMinutes,
             string redirectType,
             string cookieDomain,
-            string secretKey)
+            string secretKey,
+            bool? cookieHttpOnly)
         {
             var cookieKey = GetCookieKey(eventId);
 
@@ -184,6 +187,9 @@ namespace QueueIT.KnownUserV3.SDK
                 cookie.Domain = cookieDomain;
 
             cookie.Expires = DateTime.UtcNow.AddDays(1);
+
+            if (cookieHttpOnly.HasValue)
+                cookie.HttpOnly = cookieHttpOnly.Value;
 
             return cookie;
         }


### PR DESCRIPTION
… control how HttpOnly property on the cookie will be configured.

Added a new method parameter cookieHttpOnly on KnownUser.ValidateRequestByIntegrationConfig.
This property is then passed along towards UserInQueueStateCookieRepository.CreateCookie to determine how the HttpOnly property on the cookie will be configured.

This PR should addresses the issue that NetMatch/SunwebSportsEvents/Queue-it faced with the sale of the olympic tickets on December 10 2019. The issue that we faced here, was that when users should have been allowed on the website, the client side redirect logic could not properly read the cookie which had been written by the server (since the cookie was marked as HttpOnly). And the queue-it javascript protection of SunwebSportsEvents then added same user again at the back of the queue.

NOTE that the code change has not been tested by me. It just offers Queue-it an SDK "solution" to open the SDK for explicit control on the cookieHttpOnly property.